### PR TITLE
WIP: Allow all extensions in links

### DIFF
--- a/src/features/completionProvider.ts
+++ b/src/features/completionProvider.ts
@@ -48,13 +48,7 @@ export const provideCompletionItems = (document: TextDocument, position: Positio
     ...(isResourceAutocomplete
       ? [...cache.getWorkspaceCache().imageUris, ...cache.getWorkspaceCache().markdownUris]
       : []),
-    ...(!isResourceAutocomplete
-      ? [
-          ...cache.getWorkspaceCache().markdownUris,
-          ...cache.getWorkspaceCache().imageUris,
-          ...cache.getWorkspaceCache().otherUris,
-        ]
-      : []),
+    ...(!isResourceAutocomplete ? [...cache.getWorkspaceCache().allUris] : []),
   ];
 
   const urisByPathBasename = groupBy(uris, ({ fsPath }) => path.basename(fsPath).toLowerCase());
@@ -69,12 +63,12 @@ export const provideCompletionItems = (document: TextDocument, position: Positio
     const longRef = fsPathToRef({
       path: uri.fsPath,
       basePath: workspaceFolder.uri.fsPath,
-      keepExt: containsImageExt(uri.fsPath) || containsOtherKnownExts(uri.fsPath),
+      keepExt: !containsMarkdownExt(uri.fsPath),
     });
 
     const shortRef = fsPathToRef({
       path: uri.fsPath,
-      keepExt: containsImageExt(uri.fsPath) || containsOtherKnownExts(uri.fsPath),
+      keepExt: !containsMarkdownExt(uri.fsPath),
     });
 
     const urisGroup = urisByPathBasename[path.basename(uri.fsPath).toLowerCase()] || [];

--- a/src/workspace/cache/cache.ts
+++ b/src/workspace/cache/cache.ts
@@ -93,12 +93,10 @@ export const cacheUris = async () => {
   const markdownUris = await findNonIgnoredFiles('**/*.md');
   const imageUris = await findNonIgnoredFiles(`**/*.{${imageExts.join(',')}}`);
   const otherUris = await findNonIgnoredFiles(`**/*.{${otherExts.join(',')}}`);
+  const allUris = await findNonIgnoredFiles(`**/*`);
 
   workspaceCache.markdownUris = sortPaths(markdownUris, { pathKey: 'path', shallowFirst: true });
   workspaceCache.imageUris = sortPaths(imageUris, { pathKey: 'path', shallowFirst: true });
   workspaceCache.otherUris = sortPaths(otherUris, { pathKey: 'path', shallowFirst: true });
-  workspaceCache.allUris = sortPaths([...markdownUris, ...imageUris, ...otherUris], {
-    pathKey: 'path',
-    shallowFirst: true,
-  });
+  workspaceCache.allUris = sortPaths(allUris, { pathKey: 'path', shallowFirst: true });
 };


### PR DESCRIPTION
It's nice to be able to link to more types of files than the default. That could be code (`py`, `js`, `sh`), data (`csv`), configuration files (`yaml`), or anything else.

This fixes #592  and #593. 

I've tried this out, and it works well. It's WIP because:

* If this approach is desired, the extension code probably needs some work. There's no need for `otherExts`. The code could treat extensions as one of: markdown, images, and everything else.

* I assume tests need to be update.
