### PR TITLE
feat: add a configuration option for other file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,39 @@
 					"description": "Whether to enable links completion in the editor. Reload required!",
 					"type": "boolean"
 				},
+				"memo.links.extensions.other": {
+					"scope": "resource",
+					"description": "Other file extensions supported by links. Use a single entry of '*' to include all extensions.",
+                    "default": [
+						"doc",
+						"docx",
+						"rtf",
+						"txt",
+						"odt",
+						"xls",
+						"xlsx",
+						"ppt",
+						"pptm",
+						"pptx",
+						"pdf",
+						"pages",
+						"mp4",
+						"mov",
+						"wmv",
+						"flv",
+						"avi",
+						"mkv",
+						"mp3",
+						"webm",
+						"wav",
+						"m4a",
+						"ogg",
+						"3gp",
+						"flac",
+						"msg"
+                    ],
+					"type": "array"
+				},
 				"memo.links.following.enabled": {
 					"default": true,
 					"scope": "resource",
@@ -169,8 +202,7 @@
 					"scope": "resource",
 					"description": "Whether to enhance built-in VSCode Markdown preview with links highlight, navigation and resource embedding. Reload required!",
 					"type": "boolean"
-				}
-			}
+				}			}
 		},
 		"keybindings": [
 			{

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1181,6 +1181,23 @@ describe('findNonIgnoredFiles()', () => {
     });
   });
 
+  describe('when config includes py files', () => {
+    it('should find non-ignored files', async () => {
+      const prevConfig = getConfigProperty('memo.links.extensions.other', []);
+      await updateConfigProperty('memo.links.extensions.other', ['py']);
+      const allowedName = rndName();
+
+      await createFile(`${allowedName}.py`);
+
+      const files = await findNonIgnoredFiles('**/*.py');
+
+      expect(files).toHaveLength(1);
+      expect(path.basename(files[0].fsPath)).toBe(`${allowedName}.py`);
+
+      await updateConfigProperty('memo.links.extensions.other', prevConfig);
+    });
+  });
+
   describe('when exclude param passed explicitly and search.exclude set', () => {
     it('should find non-ignored files', async () => {
       const prevConfig = getConfigProperty('search.exclude', {});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -12,7 +12,38 @@ export const imageExts = ['png', 'jpg', 'jpeg', 'svg', 'gif', 'webp'];
 
 const imageExtsRegex = new RegExp(`.(${imageExts.join('|')})$`, 'i');
 
-export const otherExts = [
+export function getMemoConfigProperty(
+  property: 'links.format',
+  fallback: 'short',
+): 'short' | 'long';
+
+export function getMemoConfigProperty(
+  property: 'backlinksPanel.collapseParentItems',
+  fallback: null | boolean,
+): boolean;
+
+export function getMemoConfigProperty(
+  property: 'links.preview.imageMaxHeight',
+  fallback: null | number,
+): number;
+
+export function getMemoConfigProperty(
+  property: 'links.rules',
+  fallback: null | Array<LinkRuleT>,
+): LinkRuleT[];
+
+export function getMemoConfigProperty(property: MemoBoolConfigProp, fallback: boolean): boolean;
+
+export function getMemoConfigProperty(
+  property: 'links.extensions.other',
+  fallback: null | Array<String>,
+): String[];
+
+export function getMemoConfigProperty<T>(property: string, fallback: T): T {
+  return getConfigProperty(`memo.${property}`, fallback);
+}
+
+export const otherExts = getMemoConfigProperty('links.extensions.other', [
   'doc',
   'docx',
   'rtf',
@@ -39,9 +70,12 @@ export const otherExts = [
   '3gp',
   'flac',
   'msg',
-];
+]);
 
-const otherExtsRegex = new RegExp(`.(${otherExts.join('|')})$`, 'i');
+export const otherExtsRegex =
+  otherExts.length == 1 && otherExts[0] == '*'
+    ? new RegExp(`.*`, 'i')
+    : new RegExp(`.(${otherExts.join('|')})$`, 'i');
 
 // Remember to edit accordingly when extensions above edited
 export const commonExtsHint =
@@ -159,32 +193,6 @@ export type MemoBoolConfigProp =
   | 'links.sync.enabled'
   | 'backlinksPanel.enabled'
   | 'markdownPreview.enabled';
-
-export function getMemoConfigProperty(
-  property: 'links.format',
-  fallback: 'short',
-): 'short' | 'long';
-
-export function getMemoConfigProperty(
-  property: 'backlinksPanel.collapseParentItems',
-  fallback: null | boolean,
-): boolean;
-
-export function getMemoConfigProperty(
-  property: 'links.preview.imageMaxHeight',
-  fallback: null | number,
-): number;
-
-export function getMemoConfigProperty(
-  property: 'links.rules',
-  fallback: null | Array<LinkRuleT>,
-): LinkRuleT[];
-
-export function getMemoConfigProperty(property: MemoBoolConfigProp, fallback: boolean): boolean;
-
-export function getMemoConfigProperty<T>(property: string, fallback: T): T {
-  return getConfigProperty(`memo.${property}`, fallback);
-}
 
 export const matchAll = (pattern: RegExp, text: string): Array<RegExpMatchArray> => {
   let match: RegExpMatchArray | null;

--- a/src/workspace/cache/cache.ts
+++ b/src/workspace/cache/cache.ts
@@ -92,7 +92,10 @@ export const cacheUris = async () => {
   const { findNonIgnoredFiles, imageExts, otherExts } = utils();
   const markdownUris = await findNonIgnoredFiles('**/*.md');
   const imageUris = await findNonIgnoredFiles(`**/*.{${imageExts.join(',')}}`);
-  const otherUris = await findNonIgnoredFiles(`**/*.{${otherExts.join(',')}}`);
+  const otherUris =
+    otherExts.length == 1 && otherExts[0] == '*'
+      ? await findNonIgnoredFiles('**/*')
+      : await findNonIgnoredFiles(`**/*.{${otherExts.join(',')}}`);
 
   workspaceCache.markdownUris = sortPaths(markdownUris, { pathKey: 'path', shallowFirst: true });
   workspaceCache.imageUris = sortPaths(imageUris, { pathKey: 'path', shallowFirst: true });


### PR DESCRIPTION
This option allows the user to specify a list of "other" file extensions. These are in addition to Markdown and image files. This is an array. For the special case of `["*"]`, all files are supported, regardless of extension.

This partially fixes requests in #592 and #593. 

I took a shot at a test, but I can't figure out how to run tests locally, so I don't know if it works. This option also needs to be documented.